### PR TITLE
[setup] add Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,3 +76,33 @@ You are an expert iOS/macOS developer with a passion for writing clean, maintain
 Add short, actionable rules here when a pattern repeats.
 
 - TODO: Add lessons and conventions here (remove this placeholder when done)
+
+## Cursor Cloud specific instructions
+
+### Environment overview
+
+This is a pure Swift framework for Apple platforms (macOS/iOS/tvOS/visionOS/watchOS). The Cursor Cloud VM runs Ubuntu 24.04 (x86_64), so Apple-only frameworks (Combine, QuartzCore, AppKit, UIKit) are unavailable. This constrains what can be done on the VM:
+
+- **Linting works fully**: `make lint` and `make format` run SwiftFormat 0.59.1 and SwiftLint 0.63.2 (Linux binaries in `bin/`).
+- **Building and testing do NOT work**: `swift build` and `swift test` fail because the source code imports Apple-only frameworks without Linux `#if canImport()` guards. This is by design — the project targets Apple platforms only.
+
+### What you CAN do on this VM
+
+- Run `make lint` to check code style (SwiftFormat + SwiftLint).
+- Run `make format` to auto-fix formatting issues.
+- Read, search, and edit Swift source files.
+- Validate Swift syntax via the Swift 6.0.3 toolchain (e.g. `swift -parse` on individual files that don't import Apple frameworks).
+
+### What you CANNOT do on this VM
+
+- `swift build` / `swift test` / `make build` — these require macOS + Xcode.
+- Build or run playground projects — these require Xcode.
+- Run the full test suite — tests depend on Apple-only frameworks.
+
+### Linting tool setup
+
+The `bin/swiftformat` and `bin/swiftlint` binaries are gitignored. The update script downloads the correct Linux versions automatically. Versions are pinned in `bin/.versions`.
+
+### Key gotcha
+
+The `scripts/lint.sh` script requires `bc` (for timing). The update script installs it.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Cursor Cloud specific instructions to `AGENTS.md` to document the Linux development environment setup for future cloud agents.

### What changed

- Added `## Cursor Cloud specific instructions` section to `AGENTS.md` covering:
  - Environment limitations (Apple-only frameworks prevent `swift build`/`swift test` on Linux)
  - What works: linting (`make lint`, `make format`) with SwiftFormat 0.59.1 and SwiftLint 0.63.2
  - What doesn't work: building and testing (requires macOS + Xcode)
  - Linting tool setup notes (binaries are gitignored, downloaded automatically)
  - Key gotcha: `bc` dependency for `scripts/lint.sh`

### Environment setup

- **Swift**: 6.0.3 toolchain (backwards compatible with Swift 5.9 tools-version)
- **SwiftFormat**: 0.59.1 (Linux x86_64 binary)
- **SwiftLint**: 0.63.2 (Linux AMD64 binary)
- **OS**: Ubuntu 24.04 x86_64

### Tests run

- `make lint` — SwiftFormat and SwiftLint both execute successfully
- `swift --version` — confirms Swift 6.0.3 installed
- `bin/swiftformat --version` — confirms 0.59.1
- `bin/swiftlint version` — confirms 0.63.2
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0677671a-2a0a-4413-a329-88eed76ee2aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0677671a-2a0a-4413-a329-88eed76ee2aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

